### PR TITLE
fix: update bootstrap to 4.3.1 to avoid XSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3457,9 +3457,9 @@
       }
     },
     "bootstrap": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.0.tgz",
-      "integrity": "sha512-M0vqY0Z6UDweV2nLFl5dXcb+GIo53EBCGMMVxCGH5vJxl/jsr+HkULBMd4kn9rdpdBZwd3BduCgMOYOwJybo4Q=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@angular/router": "^7.2.2",
     "angular-calendar": "^0.26.6",
     "babel-cli": "^6.26.0",
-    "bootstrap": "^4.3.0",
+    "bootstrap": "^4.3.1",
     "classlist.js": "^1.1.20150312",
     "core-js": "^2.6.3",
     "date-fns": "^1.30.1",


### PR DESCRIPTION
According to [this Github security alert](https://github.com/Iteatime/Acrabadabra/network/alert/package-lock.json/bootstrap/open), linking to [this National Vulnerability Database report](https://nvd.nist.gov/vuln/detail/CVE-2019-8331) and [this Bootstrap blog post](https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/), Bootstrap `4.3.0` has an XSS vulnerability.
Fortunately Bootstrap `4.3.1` fixes this vulnerability.