### PR TITLE
docs: installation process simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ This repo contains the sources of the app, netlify functions and configuration f
     
 ### 2 Installation:
 
-* Here you have to clone this repo then you can run `npm install`.
-* Then you have to set `PDF_API_KEY`and `PDF_API_URL` as environment variable.
+Here you have to:
+* clone this repo
+* init the _pdf-to-url_ submodule by running `git submodule init ; git submodule update` (cf. [section 3.3](#3.3-pdf-api))
+* run `npm install`
+* finally you have to set `PDF_API_KEY` and `PDF_API_URL` as environment variables.
     
 ### 3 Dev server:
 


### PR DESCRIPTION
Before running `npm install` we have to `init` and `update` the _pdf-to-url_ submodule.
The procedure is detailed in the **3.3** section, but in order to clarify the installation process we indicate it in the **Installation** section.