### PR TITLE
fix(TimesheetService): Fix a bug on untokenize

### DIFF
--- a/src/app/modules/timesheet/services/timesheet.service.ts
+++ b/src/app/modules/timesheet/services/timesheet.service.ts
@@ -13,7 +13,7 @@ function untokenize(a: string): any {
     try {
       return JSON.parse(decodeURIComponent(escape(atob(a))));
     } catch {
-      alert('Votre URL est érroné');
+      alert('Données invalides');
       return false;
     }
   }

--- a/src/app/modules/timesheet/services/timesheet.service.ts
+++ b/src/app/modules/timesheet/services/timesheet.service.ts
@@ -10,7 +10,12 @@ function tokenize(a: any): string {
  ​
 function untokenize(a: string): any {
   if (a) {
-    return JSON.parse(decodeURIComponent(escape(atob(a))));
+    try {
+      return JSON.parse(decodeURIComponent(escape(atob(a))));
+    } catch {
+      alert('Votre URL est érroné');
+      return false;
+    }
   }
   return false;
 }


### PR DESCRIPTION
This bug was caused by a token that cannot be read.

Add a try-catch block on the function untokenize to catch invalid URL
Add an alert message