### PR TITLE
feat(tools): shell script for bulk deleting rebrandly links

### DIFF
--- a/scripts/tools/clean_rebrandly_links.sh
+++ b/scripts/tools/clean_rebrandly_links.sh
@@ -1,0 +1,16 @@
+for run in {1..4}
+do
+  IP=`curl --request GET \
+    --url 'https://api.rebrandly.com/v1/links?orderBy=createdAt&orderDir=asc&limit=25' \
+    --header 'apikey: 815cc16fb90f4c5ebd4f07daf7a6f7f8' \
+    --header 'content-type: application/json'`
+
+
+  for row in $(echo "${IP}" | jq '.[].id'); do
+  curl --request DELETE \
+    --url https://api.rebrandly.com/v1/links/$(echo $row | tr -d '"') \
+    --header 'apikey: 815cc16fb90f4c5ebd4f07daf7a6f7f8' \
+    --header 'content-type: application/json' \
+    --header 'workspace: e8989a355dc84230b79bf51d50e07377'
+  done
+done


### PR DESCRIPTION
Rebranly does not allow bulk delete of the created links. Deleting them one by one is very time consuming. 
This script takes the 100 oldest created links and deletes them. It is a loop of 4 x 25 delete actions, since the rebrandly api does not allow to get more than 25 link ids at once.
For a more heavy action (200 links for instance), increase the loop size