### PR TITLE
feat(tools): bulk delete script for rebrandly links

### DIFF
--- a/scripts/tools/bulk_delete_rebrandly.sh
+++ b/scripts/tools/bulk_delete_rebrandly.sh
@@ -1,0 +1,18 @@
+for run in {1..4}
+do
+  IP=`curl --request GET \
+    --url 'https://api.rebrandly.com/v1/links?orderBy=createdAt&orderDir=asc&limit=25' \
+    --header 'apikey: 815cc16fb90f4c5ebd4f07daf7a6f7f8' \
+    --header 'content-type: application/json'`
+
+
+  for row in $(echo "${IP}" | jq '.[].id'); do
+  curl --request DELETE \
+    --url https://api.rebrandly.com/v1/links/$(echo $row | tr -d '"') \
+    --header 'apikey: 815cc16fb90f4c5ebd4f07daf7a6f7f8' \
+    --header 'content-type: application/json' \
+    --header 'workspace: e8989a355dc84230b79bf51d50e07377'
+  done
+done
+
+#Install jq before (https://stedolan.github.io/jq/): `brew install jq` so the Shell script can handle JSON objects.


### PR DESCRIPTION
Rebranly does not allow bulk deletion of the created links. Deleting them one by one is very time consuming.
This script takes the 100 oldest created links and deletes them. It is actually a loop of 4 x 25 delete actions, since the Rebrandly api does not allow to get more than 25 link ids at once.
For a more heavy action  increase the loop size (to 8 iterations instead of 4 if you want to delete 200 links).
To play it safe, reduce the loop size or just remove it to delete only 25 links at once. 